### PR TITLE
fix: Fix climate deprecation

### DIFF
--- a/components/gree/climate.py
+++ b/components/gree/climate.py
@@ -32,4 +32,4 @@ async def to_code(config):
       cg.add(var.set_temperature_sensor(temperature_sensor))
 
     if CORE.is_esp8266 or CORE.is_esp32:
-        cg.add_library("crankyoldgit/IRremoteESP8266", "2.8.4")
+        cg.add_library("crankyoldgit/IRremoteESP8266", "2.8.6")

--- a/components/gree/climate.py
+++ b/components/gree/climate.py
@@ -11,12 +11,12 @@ CODEOWNERS = ["@buzzzsaw"]
 gree_ns = cg.esphome_ns.namespace("gree")
 GreeClimate = gree_ns.class_("GreeClimate", climate.Climate, cg.Component)
 
-CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(GreeClimate),
-        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
-    }
+CONFIG_SCHEMA = climate.climate_schema(GreeClimate)
+    .extend(
+        {
+            cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
+        }
 ).extend(cv.COMPONENT_SCHEMA)
 
 

--- a/components/gree/climate.py
+++ b/components/gree/climate.py
@@ -11,12 +11,11 @@ CODEOWNERS = ["@buzzzsaw"]
 gree_ns = cg.esphome_ns.namespace("gree")
 GreeClimate = gree_ns.class_("GreeClimate", climate.Climate, cg.Component)
 
-CONFIG_SCHEMA = climate.climate_schema(GreeClimate)
-    .extend(
-        {
-            cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
-        }
+CONFIG_SCHEMA = climate.climate_schema(GreeClimate).extend(
+    {
+        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
+    }
 ).extend(cv.COMPONENT_SCHEMA)
 
 

--- a/components/gree/gree.cpp
+++ b/components/gree/gree.cpp
@@ -1,5 +1,6 @@
 #include "gree.h"
 #include "esphome/core/log.h"
+#include <set>
 
 static const char *const TAG = "gree.climate";
 
@@ -50,8 +51,8 @@ climate::ClimateTraits GreeClimate::traits()
 {
   auto traits = climate::ClimateTraits();
 
-  traits.set_supports_current_temperature(true);
-  traits.set_supports_two_point_target_temperature(false);
+  traits.add_feature_flags(esphome::climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+  
   if (this->visual_min_temperature_override_.has_value()) 
   {
     traits.set_visual_min_temperature(*this->visual_min_temperature_override_);
@@ -65,26 +66,29 @@ climate::ClimateTraits GreeClimate::traits()
     traits.set_visual_temperature_step(*this->visual_target_temperature_step_override_);
   }
 
-  std::set<climate::ClimateMode> climateModes; 
-  climateModes.insert(climate::CLIMATE_MODE_OFF);
-  climateModes.insert(climate::CLIMATE_MODE_COOL);
-  climateModes.insert(climate::CLIMATE_MODE_HEAT);
-  climateModes.insert(climate::CLIMATE_MODE_DRY);
-  climateModes.insert(climate::CLIMATE_MODE_FAN_ONLY);
-  traits.set_supported_modes(climateModes);
+  auto modes = esphome::climate::ClimateModeMask{
+    esphome::climate::CLIMATE_MODE_HEAT,
+    esphome::climate::CLIMATE_MODE_COOL,
+    esphome::climate::CLIMATE_MODE_HEAT,
+    esphome::climate::CLIMATE_MODE_DRY,
+    esphome::climate::CLIMATE_MODE_FAN_ONLY
+  };
+  traits.set_supported_modes(modes);
 
-  std::set<climate::ClimateFanMode> climateFanModes; 
-  climateFanModes.insert(climate::CLIMATE_FAN_AUTO);
-  climateFanModes.insert(climate::CLIMATE_FAN_LOW);
-  climateFanModes.insert(climate::CLIMATE_FAN_MEDIUM);
-  climateFanModes.insert(climate::CLIMATE_FAN_HIGH);
-  climateFanModes.insert(climate::CLIMATE_FAN_FOCUS);
-  traits.set_supported_fan_modes(climateFanModes);
+  auto fanModes = esphome::climate::ClimateFanModeMask{
+    esphome::climate::CLIMATE_FAN_AUTO,
+    esphome::climate::CLIMATE_FAN_LOW,
+    esphome::climate::CLIMATE_FAN_MEDIUM,
+    esphome::climate::CLIMATE_FAN_HIGH,
+    esphome::climate::CLIMATE_FAN_FOCUS
+  };
+  traits.set_supported_fan_modes(fanModes);
 
-  std::set<climate::ClimateSwingMode> climateSwingModes;
-  climateSwingModes.insert(climate::CLIMATE_SWING_OFF);
-  climateSwingModes.insert(climate::CLIMATE_SWING_VERTICAL);
-  traits.set_supported_swing_modes(climateSwingModes);
+  auto swingModes = esphome::climate::ClimateSwingModeMask{
+    esphome::climate::CLIMATE_SWING_OFF,
+    esphome::climate::CLIMATE_SWING_VERTICAL,
+  };
+  traits.set_supported_swing_modes(swingModes);
 
   return traits;
 }


### PR DESCRIPTION
Fix some breaking changes coming from ESPHome:
 - Python `CLIMATE_SCHEMA `constant replaced by function
 - Fixed traits handling with new masks

Additionally bumped IR remote lib version (minor).